### PR TITLE
fix: use topic_summary for conversation title when available

### DIFF
--- a/packages/lightspeed-client/src/lib/client.ts
+++ b/packages/lightspeed-client/src/lib/client.ts
@@ -72,7 +72,9 @@ export class LightspeedClient
       const conversations: IConversation[] =
         conversationsResponse.conversations.map((conv) => ({
           id: conv.conversation_id,
-          title: conv.topic_summary || `Conversation (${conv.message_count || 0} messages)`,
+          title:
+            conv.topic_summary ||
+            `Conversation (${conv.message_count || 0} messages)`,
           locked: false,
           createdAt: conv.created_at ? new Date(conv.created_at) : new Date(),
         }));

--- a/packages/lightspeed-client/src/lib/client.ts
+++ b/packages/lightspeed-client/src/lib/client.ts
@@ -72,7 +72,7 @@ export class LightspeedClient
       const conversations: IConversation[] =
         conversationsResponse.conversations.map((conv) => ({
           id: conv.conversation_id,
-          title: `Conversation (${conv.message_count || 0} messages)`,
+          title: conv.topic_summary || `Conversation (${conv.message_count || 0} messages)`,
           locked: false,
           createdAt: conv.created_at ? new Date(conv.created_at) : new Date(),
         }));

--- a/packages/lightspeed-client/src/lib/types.ts
+++ b/packages/lightspeed-client/src/lib/types.ts
@@ -535,6 +535,7 @@ export interface Configuration {
  */
 export interface ConversationDetails {
   conversation_id: string;
+  topic_summary?: string | null;
   created_at: string | null;
   last_message_at: string | null;
   message_count: number | null;


### PR DESCRIPTION
For more details: https://github.com/openshift/genie-web-client/pull/100
https://github.com/lightspeed-core/lightspeed-stack/blob/main/docs/openapi.md#conversationdetails