### PR TITLE
GIE-464 expose stream abort cancel hook

### DIFF
--- a/packages/ai-client-state/src/lib/state-manager.spec.ts
+++ b/packages/ai-client-state/src/lib/state-manager.spec.ts
@@ -184,9 +184,130 @@ describe('ClientStateManager', () => {
       expect(mockClient.sendMessage).toHaveBeenCalledWith(
         'conv-456',
         'Stream this',
-        { stream: true, handleChunk: expect.any(Function) }
+        expect.objectContaining({
+          stream: true,
+          handleChunk: expect.any(Function),
+          signal: expect.anything(),
+        })
       );
       expect(response).toBeDefined();
+    });
+
+    it('should abort active streaming request via abortStream', async () => {
+      mockClient.sendMessage.mockImplementation(
+        (_conversationId, _query, enhancedOptions) =>
+          new Promise((_resolve, reject) => {
+            enhancedOptions?.signal?.addEventListener('abort', () => {
+              const abortError = new Error('aborted');
+              abortError.name = 'AbortError';
+              reject(abortError);
+            });
+          })
+      );
+
+      const messagePromise = stateManager.sendMessage('abort this stream', {
+        stream: true,
+      });
+      expect(stateManager.getMessageInProgress()).toBe(true);
+
+      stateManager.abortStream();
+
+      await expect(messagePromise).rejects.toThrow('aborted');
+      expect(stateManager.getMessageInProgress()).toBe(false);
+      expect(stateManager.getState().currentAbortController).toBeNull();
+      expect(stateManager.getActiveConversationMessages()).toHaveLength(1);
+      expect(stateManager.getActiveConversationMessages()[0].role).toBe('user');
+    });
+
+    it('should merge external signal with internal abort controller', async () => {
+      mockClient.sendMessage.mockImplementation(
+        (_conversationId, _query, enhancedOptions) =>
+          new Promise((_resolve, reject) => {
+            enhancedOptions?.signal?.addEventListener('abort', () => {
+              reject(new Error('external-abort'));
+            });
+          })
+      );
+
+      const externalController = new AbortController();
+      const messagePromise = stateManager.sendMessage('external abort', {
+        stream: true,
+        signal: externalController.signal,
+      });
+
+      externalController.abort();
+
+      await expect(messagePromise).rejects.toThrow('external-abort');
+      expect(stateManager.getMessageInProgress()).toBe(false);
+    });
+
+    it('should emit STREAM_ABORT and IN_PROGRESS when aborting', async () => {
+      mockClient.sendMessage.mockImplementation(
+        (_conversationId, _query, enhancedOptions) =>
+          new Promise((_resolve, reject) => {
+            enhancedOptions?.signal?.addEventListener('abort', () => {
+              const abortError = new Error('aborted');
+              abortError.name = 'AbortError';
+              reject(abortError);
+            });
+          })
+      );
+
+      const inProgressCallback = jest.fn();
+      const abortCallback = jest.fn();
+      stateManager.subscribe(Events.IN_PROGRESS, inProgressCallback);
+      stateManager.subscribe(Events.STREAM_ABORT, abortCallback);
+
+      const messagePromise = stateManager.sendMessage('emit abort event', {
+        stream: true,
+      });
+
+      stateManager.abortStream();
+
+      // start IN_PROGRESS, then abort IN_PROGRESS false (finally may emit once more)
+      expect(inProgressCallback.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(abortCallback).toHaveBeenCalledTimes(1);
+      expect(stateManager.getMessageInProgress()).toBe(false);
+
+      await expect(messagePromise).rejects.toThrow('aborted');
+    });
+
+    it('should not let aborted request cleanup clobber a newer request', async () => {
+      const pendingRejects: Array<(error: Error) => void> = [];
+      mockClient.sendMessage.mockImplementation(
+        (_conversationId, _query, enhancedOptions) =>
+          new Promise((_resolve, reject) => {
+            pendingRejects.push(reject);
+            enhancedOptions?.signal?.addEventListener('abort', () => {
+              const abortError = new Error('aborted');
+              abortError.name = 'AbortError';
+              reject(abortError);
+            });
+          })
+      );
+
+      // start request #1
+      const firstMessagePromise = stateManager.sendMessage('first', {
+        stream: true,
+      });
+      stateManager.abortStream();
+
+      // start request #2 before request #1 settles
+      const secondMessagePromise = stateManager.sendMessage('second', {
+        stream: true,
+      });
+
+      // settle request #1 rejection first
+      await expect(firstMessagePromise).rejects.toThrow('aborted');
+
+      // ensure request #2 is still considered in progress (not clobbered by #1 cleanup)
+      expect(stateManager.getMessageInProgress()).toBe(true);
+      expect(stateManager.getState().currentAbortController).not.toBeNull();
+
+      // finish request #2
+      pendingRejects[pendingRejects.length - 1](new Error('second-failed'));
+      await expect(secondMessagePromise).rejects.toThrow('second-failed');
+      expect(stateManager.getMessageInProgress()).toBe(false);
     });
   });
 
@@ -1320,6 +1441,18 @@ describe('ClientStateManager', () => {
       await stateManager.deleteConversation('conv-evt');
 
       expect(conversationsCallback).toHaveBeenCalled();
+    });
+  });
+
+  describe('Abort Event Semantics', () => {
+    it('should not emit STREAM_ABORT during notifyAll flows', async () => {
+      const streamAbortCallback = jest.fn();
+      stateManager.subscribe(Events.STREAM_ABORT, streamAbortCallback);
+
+      // createNewConversation triggers notifyAll internally
+      await stateManager.createNewConversation(true);
+
+      expect(streamAbortCallback).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ai-client-state/src/lib/state-manager.ts
+++ b/packages/ai-client-state/src/lib/state-manager.ts
@@ -23,6 +23,7 @@ export enum Events {
   INITIALIZING_MESSAGES = 'initializing-messages',
   INIT_LIMITATION = 'init-limitation',
   STREAM_CHUNK = 'stream-chunk',
+  STREAM_ABORT = 'stream-abort',
 }
 
 export interface Message<
@@ -50,6 +51,7 @@ export interface Conversation<
 
 export interface MessageOptions {
   stream?: boolean;
+  signal?: AbortSignal;
   [key: string]: unknown;
 }
 
@@ -59,11 +61,14 @@ interface ClientState<
   conversations: Record<string, Conversation<T>>;
   activeConversationId: string | null;
   messageInProgress: boolean;
+  activeRequestId: number | null;
+  nextRequestId: number;
   isInitialized: boolean;
   isInitializing: boolean;
   client: IAIClient;
   initLimitation: ClientInitLimitation | undefined;
   promotionRetryCount: number;
+  currentAbortController: AbortController | null;
 }
 
 interface EventSubscription {
@@ -83,6 +88,7 @@ export type StateManager<
   getActiveConversationMessages: () => Message<T>[];
   getActiveConversationStreamChunk: () => IStreamChunk<T> | undefined;
   sendMessage: (query: UserQuery, options?: MessageOptions) => Promise<any>;
+  abortStream: () => void;
   getMessageInProgress: () => boolean;
   getState: () => ClientState<T>;
   subscribe: (event: Events, callback: () => void) => () => void;
@@ -103,11 +109,14 @@ export function createClientStateManager<
     conversations: {},
     activeConversationId: null,
     messageInProgress: false,
+    activeRequestId: null,
+    nextRequestId: 1,
     isInitialized: false,
     isInitializing: false,
     client,
     initLimitation: undefined,
     promotionRetryCount: 0,
+    currentAbortController: null,
   };
 
   const eventSubscriptions: Record<string, EventSubscription[]> = {
@@ -117,6 +126,7 @@ export function createClientStateManager<
     [Events.CONVERSATIONS]: [],
     [Events.INITIALIZING_MESSAGES]: [],
     [Events.STREAM_CHUNK]: [],
+    [Events.STREAM_ABORT]: [],
   };
 
   function notify(event: Events) {
@@ -414,7 +424,27 @@ export function createClientStateManager<
 
     // Set message in progress
     state.messageInProgress = true;
+    const requestId = state.nextRequestId++;
+    state.activeRequestId = requestId;
     notify(Events.IN_PROGRESS);
+
+    // create AbortController for this request
+    const abortController = new AbortController();
+    state.currentAbortController = abortController;
+    const externalSignal = options?.signal;
+    const handleExternalAbort = () => {
+      abortController.abort();
+    };
+
+    if (externalSignal) {
+      if (externalSignal.aborted) {
+        abortController.abort();
+      } else {
+        externalSignal.addEventListener('abort', handleExternalAbort, {
+          once: true,
+        });
+      }
+    }
 
     try {
       // Auto-create temporary conversation if none exists
@@ -456,6 +486,7 @@ export function createClientStateManager<
         conversation.messages.push(lockedMessage);
         notify(Events.MESSAGE);
         state.messageInProgress = false;
+        state.currentAbortController = null;
         notify(Events.IN_PROGRESS);
         return;
       }
@@ -472,6 +503,7 @@ export function createClientStateManager<
       // Always provide handleChunk callback for state updates - client handles streaming internally
       const enhancedOptions: ISendMessageOptions<T> = {
         ...options,
+        signal: abortController.signal,
         handleChunk: (chunk) => {
           botMessage.answer = chunk.answer;
           botMessage.id = chunk.messageId ?? botMessage.id;
@@ -486,6 +518,7 @@ export function createClientStateManager<
       return client
         .sendMessage(originalConversationId, query, enhancedOptions)
         .catch((error) => {
+          // remove placeholder bot message on all failures, including aborts
           removeMessageFromConversation(botMessage.id, originalConversationId);
           notify(Events.MESSAGE);
           throw error;
@@ -510,13 +543,26 @@ export function createClientStateManager<
           return response;
         })
         .finally(() => {
-          state.messageInProgress = false;
-          notify(Events.IN_PROGRESS);
+          if (externalSignal) {
+            externalSignal.removeEventListener('abort', handleExternalAbort);
+          }
+          // only cleanup if this is still the active request.
+          // prevent an old request's finally from clobbering a newer in-flight request.
+          if (state.activeRequestId === requestId) {
+            state.messageInProgress = false;
+            state.currentAbortController = null;
+            state.activeRequestId = null;
+            notify(Events.IN_PROGRESS);
+          }
         });
     } catch (error) {
       // Make sure to reset progress flag on any error
-      state.messageInProgress = false;
-      notify(Events.IN_PROGRESS);
+      if (state.activeRequestId === requestId) {
+        state.messageInProgress = false;
+        state.currentAbortController = null;
+        state.activeRequestId = null;
+        notify(Events.IN_PROGRESS);
+      }
       throw error;
     }
   }
@@ -579,6 +625,17 @@ export function createClientStateManager<
     return resp;
   }
 
+  function abortStream(): void {
+    if (state.currentAbortController) {
+      state.currentAbortController.abort();
+      state.currentAbortController = null;
+      state.messageInProgress = false;
+      state.activeRequestId = null;
+      notify(Events.IN_PROGRESS);
+      notify(Events.STREAM_ABORT);
+    }
+  }
+
   function subscribe(event: Events, callback: () => void) {
     const id = crypto.randomUUID();
     const subscription: EventSubscription = { id, callback };
@@ -638,6 +695,7 @@ export function createClientStateManager<
     getActiveConversationMessages,
     getActiveConversationStreamChunk,
     sendMessage,
+    abortStream,
     getMessageInProgress,
     getState,
     subscribe,

--- a/packages/ai-react-state/src/index.ts
+++ b/packages/ai-react-state/src/index.ts
@@ -2,6 +2,7 @@ export * from './AIStateProvider';
 export * from './AiStateContext';
 export * from './useActiveConversation';
 export * from './useSendMessage';
+export * from './useAbortStream';
 export * from './useMessages';
 export * from './useActiveInProgress';
 export * from './useConversations';

--- a/packages/ai-react-state/src/useAbortStream.spec.tsx
+++ b/packages/ai-react-state/src/useAbortStream.spec.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { useAbortStream } from './useAbortStream';
+import { AIStateProvider } from './AIStateProvider';
+import {
+  createClientStateManager,
+  StateManager,
+} from '@redhat-cloud-services/ai-client-state';
+import { IAIClient } from '@redhat-cloud-services/ai-client-common';
+
+describe('useAbortStream', () => {
+  let mockClient: IAIClient;
+  let stateManager: StateManager;
+
+  const createWrapper = (stateManagerInstance: StateManager) => {
+    return ({ children }: { children: React.ReactNode }) => (
+      <AIStateProvider stateManager={stateManagerInstance}>
+        {children}
+      </AIStateProvider>
+    );
+  };
+
+  beforeEach(() => {
+    mockClient = {
+      sendMessage: jest.fn().mockResolvedValue({ answer: 'test response' }),
+      healthCheck: jest.fn().mockResolvedValue({ status: 'ok' }),
+      getConversationHistory: jest.fn().mockResolvedValue([]),
+      init: jest.fn().mockResolvedValue('initial-conversation-id'),
+      getDefaultStreamingHandler: jest.fn().mockReturnValue({
+        onStart: jest.fn(),
+        onChunk: jest.fn(),
+        onComplete: jest.fn(),
+        onError: jest.fn(),
+      }),
+      getInitOptions: jest.fn().mockReturnValue({
+        initializeNewConversation: true,
+      }),
+    };
+
+    stateManager = createClientStateManager(mockClient);
+  });
+
+  it('should return abortStream function from state manager', () => {
+    const wrapper = createWrapper(stateManager);
+    const { result } = renderHook(() => useAbortStream(), { wrapper });
+
+    expect(typeof result.current).toBe('function');
+    expect(result.current).toBe(stateManager.abortStream);
+  });
+
+  it('should call state manager abortStream when invoked', () => {
+    const wrapper = createWrapper(stateManager);
+    const abortSpy = jest.spyOn(stateManager, 'abortStream');
+    const { result } = renderHook(() => useAbortStream(), { wrapper });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(abortSpy).toHaveBeenCalledTimes(1);
+    abortSpy.mockRestore();
+  });
+
+  it('should handle context not being available', () => {
+    const originalConsoleError = console.error;
+    console.error = jest.fn();
+
+    expect(() => {
+      renderHook(() => useAbortStream());
+    }).toThrow('AIStateContext not initialized');
+
+    console.error = originalConsoleError;
+  });
+});

--- a/packages/ai-react-state/src/useAbortStream.ts
+++ b/packages/ai-react-state/src/useAbortStream.ts
@@ -1,0 +1,8 @@
+import { useContext, useMemo } from 'react';
+import { AIStateContext } from './AiStateContext';
+
+export function useAbortStream() {
+  const { getState } = useContext(AIStateContext);
+  const abortStream = useMemo(() => getState().abortStream, [getState]);
+  return abortStream;
+}


### PR DESCRIPTION
Background  
https://issues.redhat.com/browse/GIE-464

When a response is streaming, the UI can hit “message already being processed” conflicts if users try to interrupt flow (send/edit) without a true cancel path.  
Backend confirmed that dropping the SSE connection stops generation server-side, but our state libraries did not expose a client-side abort API for UI to call.

What this PR changes  
This PR adds stream abort support to the shared client state libraries so consuming UIs can implement Stop and Edit-interrupt behavior.

In ai-client-state:
- Added `signal?: AbortSignal` to `MessageOptions`.
- Added `abortStream()` to the state manager public API.
- Wired `sendMessage()` to create/manage an internal `AbortController` and pass its signal into client requests.
- Connected optional external signals to the same internal abort path.
- Added `STREAM_ABORT` event and emit it only on explicit abort.
- Made in-progress cleanup race-safe so an old aborted request cannot clobber a newer in-flight request.
- On aborted/failed stream requests, remove the in-progress bot placeholder message cleanly.

In ai-react-state:
- Added `useAbortStream()` hook.
- Exported `useAbortStream()` from package index for consumers.

Why this approach  
We needed a cancellation mechanism that is explicit, safe under overlapping request timing, and easy for UI code to consume.  
This implementation keeps cancel behavior in one place (state manager), gives React consumers a simple hook, and avoids stale in-progress state after aborts.

Tests added/updated  
ai-client-state:
- Updated streaming assertion to validate signal propagation.
- Added tests for:
  - aborting active stream via `abortStream()`
  - external signal + internal controller integration
  - abort event and in-progress transitions
  - race case where request A abort cleanup must not overwrite request B state
  - ensuring `STREAM_ABORT` is not emitted during normal notifyAll flows

ai-react-state:
- Added `useAbortStream` hook tests for:
  - context wiring
  - callback passthrough
  - error behavior outside provider context

Validation run  
- ai-client-state lint: pass (warnings only)  
- ai-react-state lint: pass (warnings only)  
- ai-client-state tests: pass  
- ai-react-state tests: pass  
- ai-client-state and ai-react-state build: pass

Scope note  

This PR provides library APIs and behavior needed for stream cancellation.  