### PR TITLE
feat(clients): add new hcc-ai-assistant client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7577,6 +7577,10 @@
       "resolved": "packages/arh-client",
       "link": true
     },
+    "node_modules/@redhat-cloud-services/hcc-ai-assistant-client": {
+      "resolved": "packages/hcc-ai-assistant-client",
+      "link": true
+    },
     "node_modules/@redhat-cloud-services/lightspeed-client": {
       "resolved": "packages/lightspeed-client",
       "link": true
@@ -34048,6 +34052,13 @@
     "packages/arh-client": {
       "name": "@redhat-cloud-services/arh-client",
       "version": "0.12.0",
+      "dependencies": {
+        "@redhat-cloud-services/ai-client-common": "0.13.0"
+      }
+    },
+    "packages/hcc-ai-assistant-client": {
+      "name": "@redhat-cloud-services/hcc-ai-assistant-client",
+      "version": "0.1.0",
       "dependencies": {
         "@redhat-cloud-services/ai-client-common": "0.13.0"
       }

--- a/packages/hcc-ai-assistant-client/.eslintrc.json
+++ b/packages/hcc-ai-assistant-client/.eslintrc.json
@@ -1,0 +1,32 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": [
+              "{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/hcc-ai-assistant-client/jest.config.ts
+++ b/packages/hcc-ai-assistant-client/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  displayName: 'hcc-ai-assistant-client',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/packages/hcc-ai-assistant-client',
+};

--- a/packages/hcc-ai-assistant-client/package.json
+++ b/packages/hcc-ai-assistant-client/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@redhat-cloud-services/hcc-ai-assistant-client",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "@redhat-cloud-services/ai-client-common": "0.13.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/hcc-ai-assistant-client/project.json
+++ b/packages/hcc-ai-assistant-client/project.json
@@ -1,0 +1,37 @@
+{
+  "name": "hcc-ai-assistant-client",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/hcc-ai-assistant-client/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/hcc-ai-assistant-client",
+        "main": "packages/hcc-ai-assistant-client/src/index.ts",
+        "tsConfig": "packages/hcc-ai-assistant-client/tsconfig.lib.json",
+        "assets": []
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "packages/hcc-ai-assistant-client/jest.config.ts"
+      }
+    }
+  }
+}

--- a/packages/hcc-ai-assistant-client/src/index.ts
+++ b/packages/hcc-ai-assistant-client/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib';

--- a/packages/hcc-ai-assistant-client/src/lib/client.spec.ts
+++ b/packages/hcc-ai-assistant-client/src/lib/client.spec.ts
@@ -1,0 +1,603 @@
+import { HCCAIAssistantClient } from './client';
+import {
+  HCCAIAssistantClientConfig,
+  HCCAIAssistantUnauthorizedError,
+  HCCAIAssistantValidationError,
+  HCCAIAssistantQuotaExceededError,
+  HCCAIAssistantServerError,
+  extractErrorMessage,
+} from './types';
+import { AIClientError } from '@redhat-cloud-services/ai-client-common';
+
+const BASE_URL = 'https://api.example.com';
+const QUERY_URL = `${BASE_URL}/v1/query`;
+const HEALTH_URL = `${BASE_URL}/v1/health`;
+const TEMP_CONVERSATION_ID = '__temp_hcc_ai_assistant_conversation__';
+
+function mockErrorResponse(
+  status: number,
+  statusText: string,
+  body: unknown = {}
+): Response {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe('HCCAIAssistantClient', () => {
+  let client: HCCAIAssistantClient;
+  let config: HCCAIAssistantClientConfig;
+  let mockFetch: jest.MockedFunction<typeof fetch>;
+  let mockResponse: Partial<Response>;
+
+  const defaultConfig: HCCAIAssistantClientConfig = {
+    baseUrl: BASE_URL,
+    provider: 'google-vertex',
+    model: 'publishers/google/models/gemini-2.5-flash',
+    generateTopicSummary: false,
+  };
+
+  const mockAPIResponse = {
+    conversation_id: 'conv-abc123',
+    response: 'Here are the principals in your organization.',
+    rag_chunks: [],
+    referenced_documents: [{ title: 'RBAC docs', url: 'https://example.com' }],
+    truncated: false,
+    input_tokens: 1500,
+    output_tokens: 42,
+    available_quotas: {},
+    tool_calls: [],
+    tool_results: [],
+  };
+
+  function getRequestBody(): Record<string, unknown> {
+    return JSON.parse(
+      (mockFetch.mock.calls[0][1] as RequestInit).body as string
+    );
+  }
+
+  beforeEach(() => {
+    mockFetch = jest.fn();
+    mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: jest.fn().mockResolvedValue(mockAPIResponse),
+    };
+    mockFetch.mockResolvedValue(mockResponse as Response);
+
+    config = { ...defaultConfig, fetchFunction: mockFetch };
+    client = new HCCAIAssistantClient(config);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should create an instance with required config', () => {
+      expect(client).toBeDefined();
+      expect(client).toBeInstanceOf(HCCAIAssistantClient);
+    });
+
+    it('should strip trailing slash from baseUrl', async () => {
+      const trailingSlashClient = new HCCAIAssistantClient({
+        ...config,
+        baseUrl: `${BASE_URL}/`,
+      });
+
+      await trailingSlashClient.sendMessage(TEMP_CONVERSATION_ID, 'hello');
+
+      expect(mockFetch).toHaveBeenCalledWith(QUERY_URL, expect.any(Object));
+    });
+
+    it('should omit optional fields when not provided', async () => {
+      const minimalClient = new HCCAIAssistantClient({
+        baseUrl: 'https://example.com',
+        fetchFunction: mockFetch,
+      });
+
+      await minimalClient.sendMessage(TEMP_CONVERSATION_ID, 'hello');
+
+      const body = getRequestBody();
+      expect(body['query']).toBe('hello');
+      expect(body['provider']).toBeUndefined();
+      expect(body['model']).toBeUndefined();
+      expect(body['generate_topic_summary']).toBeUndefined();
+    });
+  });
+
+  describe('init', () => {
+    it('should fetch conversations from /v1/conversations', async () => {
+      (mockResponse.json as jest.Mock).mockResolvedValue({
+        conversations: [
+          {
+            conversation_id: 'conv-1',
+            topic_summary: 'RBAC principals',
+            created_at: '2025-01-15T10:00:00Z',
+            last_message_at: '2025-01-15T10:05:00Z',
+            message_count: 3,
+            last_used_model: null,
+            last_used_provider: null,
+          },
+          {
+            conversation_id: 'conv-2',
+            topic_summary: null,
+            created_at: null,
+            last_message_at: null,
+            message_count: null,
+            last_used_model: null,
+            last_used_provider: null,
+          },
+        ],
+      });
+
+      const result = await client.init();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${BASE_URL}/v1/conversations`,
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(result.conversations).toHaveLength(2);
+      expect(result.conversations[0]).toEqual({
+        id: 'conv-1',
+        title: 'RBAC principals',
+        locked: false,
+        createdAt: new Date('2025-01-15T10:00:00Z'),
+      });
+      expect(result.conversations[1]).toEqual({
+        id: 'conv-2',
+        title: 'New Conversation',
+        locked: false,
+        createdAt: expect.any(Date),
+      });
+    });
+  });
+
+  describe('createNewConversation', () => {
+    it('should return a conversation with the temp ID', async () => {
+      const conversation = await client.createNewConversation();
+
+      expect(conversation).toEqual({
+        id: TEMP_CONVERSATION_ID,
+        title: 'New Conversation',
+        locked: false,
+        createdAt: expect.any(Date),
+      });
+    });
+  });
+
+  describe('getConversationHistory', () => {
+    it('should fetch and map conversation turns to messages', async () => {
+      (mockResponse.json as jest.Mock).mockResolvedValue({
+        conversation_id: 'conv-1',
+        chat_history: [
+          {
+            messages: [
+              { content: 'List my principals', type: 'user' },
+              {
+                content: 'Here are your principals.',
+                type: 'assistant',
+                referenced_documents: [
+                  { doc_title: 'RBAC docs', doc_url: 'https://example.com' },
+                ],
+              },
+            ],
+            provider: 'google-vertex',
+            model: 'gemini-2.5-flash',
+            started_at: '2025-01-15T10:00:00Z',
+            completed_at: '2025-01-15T10:00:05Z',
+          },
+        ],
+      });
+
+      const history = await client.getConversationHistory('conv-1');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${BASE_URL}/v1/conversations/conv-1`,
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(history).toHaveLength(2);
+      expect(history![0]).toEqual({
+        message_id: expect.any(String),
+        answer: '',
+        input: 'List my principals',
+        date: new Date('2025-01-15T10:00:00Z'),
+        additionalAttributes: undefined,
+      });
+      expect(history![1]).toEqual({
+        message_id: expect.any(String),
+        answer: 'Here are your principals.',
+        input: '',
+        date: new Date('2025-01-15T10:00:00Z'),
+        additionalAttributes: {
+          referencedDocuments: [
+            { doc_title: 'RBAC docs', doc_url: 'https://example.com' },
+          ],
+        },
+      });
+    });
+
+    it('should filter out system and developer messages', async () => {
+      (mockResponse.json as jest.Mock).mockResolvedValue({
+        conversation_id: 'conv-1',
+        chat_history: [
+          {
+            messages: [
+              { content: 'System prompt', type: 'system' },
+              { content: 'Hello', type: 'user' },
+              { content: 'Dev note', type: 'developer' },
+              { content: 'Hi there!', type: 'assistant' },
+            ],
+            provider: 'google-vertex',
+            model: 'gemini-2.5-flash',
+            started_at: '2025-01-15T10:00:00Z',
+            completed_at: '2025-01-15T10:00:05Z',
+          },
+        ],
+      });
+
+      const history = await client.getConversationHistory('conv-1');
+
+      expect(history).toHaveLength(2);
+      expect(history![0]['input']).toBe('Hello');
+      expect(history![1]['answer']).toBe('Hi there!');
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('should make GET request to /v1/health', async () => {
+      const healthData = { status: 'healthy' };
+      (mockResponse.json as jest.Mock).mockResolvedValue(healthData);
+
+      const result = await client.healthCheck();
+
+      expect(mockFetch).toHaveBeenCalledWith(HEALTH_URL, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      });
+      expect(result).toEqual(healthData);
+    });
+
+    it('should pass custom headers', async () => {
+      (mockResponse.json as jest.Mock).mockResolvedValue({});
+
+      await client.healthCheck({ headers: { Authorization: 'Bearer token' } });
+
+      expect(mockFetch).toHaveBeenCalledWith(HEALTH_URL, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          Authorization: 'Bearer token',
+        },
+      });
+    });
+
+    it('should pass abort signal', async () => {
+      (mockResponse.json as jest.Mock).mockResolvedValue({});
+      const controller = new AbortController();
+
+      await client.healthCheck({ signal: controller.signal });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ signal: controller.signal })
+      );
+    });
+  });
+
+  describe('sendMessage', () => {
+    it('should POST to /v1/query with provider and model', async () => {
+      await client.sendMessage('conv-123', 'List my principals');
+
+      expect(mockFetch).toHaveBeenCalledWith(QUERY_URL, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: 'List my principals',
+          provider: 'google-vertex',
+          model: 'publishers/google/models/gemini-2.5-flash',
+          generate_topic_summary: false,
+          conversation_id: 'conv-123',
+        }),
+      });
+    });
+
+    it('should omit conversation_id for the temp conversation ID', async () => {
+      await client.sendMessage(TEMP_CONVERSATION_ID, 'Hello');
+      expect(getRequestBody()['conversation_id']).toBeUndefined();
+    });
+
+    it('should include conversation_id for real conversations', async () => {
+      await client.sendMessage('real-conv-id', 'Hello');
+      expect(getRequestBody()['conversation_id']).toBe('real-conv-id');
+    });
+
+    it('should map API response to IMessageResponse', async () => {
+      const result = await client.sendMessage('conv-123', 'test');
+
+      expect(result.answer).toBe(
+        'Here are the principals in your organization.'
+      );
+      expect(result.conversationId).toBe('conv-abc123');
+      expect(result.date).toBeInstanceOf(Date);
+      expect(result.messageId).toBeDefined();
+      expect(result.additionalAttributes).toEqual({
+        referencedDocuments: [
+          { title: 'RBAC docs', url: 'https://example.com' },
+        ],
+        truncated: false,
+        inputTokens: 1500,
+        outputTokens: 42,
+      });
+    });
+
+    it('should use the configured generateTopicSummary value', async () => {
+      const summaryClient = new HCCAIAssistantClient({
+        ...config,
+        generateTopicSummary: true,
+      });
+
+      await summaryClient.sendMessage(TEMP_CONVERSATION_ID, 'Hello');
+      expect(getRequestBody()['generate_topic_summary']).toBe(true);
+    });
+
+    it('should pass custom headers', async () => {
+      await client.sendMessage('conv-123', 'test', {
+        headers: { 'X-Request-ID': 'req-456' },
+      });
+
+      const headers = (mockFetch.mock.calls[0][1] as RequestInit).headers;
+      expect(headers).toEqual(
+        expect.objectContaining({ 'X-Request-ID': 'req-456' })
+      );
+    });
+
+    it('should pass abort signal', async () => {
+      const controller = new AbortController();
+
+      await client.sendMessage('conv-123', 'test', {
+        signal: controller.signal,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ signal: controller.signal })
+      );
+    });
+  });
+
+  describe('extractErrorMessage', () => {
+    it('should extract from Lightspeed Stack format', () => {
+      expect(
+        extractErrorMessage(
+          { detail: { response: 'Something failed', cause: 'Unknown' } },
+          'fallback'
+        )
+      ).toBe('Something failed');
+    });
+
+    it('should extract from FastAPI validation format', () => {
+      expect(
+        extractErrorMessage({ detail: [{ msg: 'field required' }] }, 'fallback')
+      ).toBe('field required');
+    });
+
+    it('should extract from message field', () => {
+      expect(extractErrorMessage({ message: 'Not found' }, 'fallback')).toBe(
+        'Not found'
+      );
+    });
+
+    it('should extract from error field', () => {
+      expect(extractErrorMessage({ error: 'Bad request' }, 'fallback')).toBe(
+        'Bad request'
+      );
+    });
+
+    it('should return fallback for null body', () => {
+      expect(extractErrorMessage(null, 'fallback')).toBe('fallback');
+    });
+
+    it('should return fallback for non-object body', () => {
+      expect(extractErrorMessage('string', 'fallback')).toBe('fallback');
+    });
+
+    it('should return fallback when no recognized fields exist', () => {
+      expect(extractErrorMessage({ unrelated: true }, 'fallback')).toBe(
+        'fallback'
+      );
+    });
+
+    it('should return fallback for empty detail array', () => {
+      expect(extractErrorMessage({ detail: [] }, 'fallback')).toBe('fallback');
+    });
+
+    it('should return fallback when detail object has no response field', () => {
+      expect(
+        extractErrorMessage({ detail: { cause: 'something' } }, 'fallback')
+      ).toBe('fallback');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw HCCAIAssistantUnauthorizedError for 401 responses', async () => {
+      mockFetch.mockResolvedValue(
+        mockErrorResponse(401, 'Unauthorized', {
+          detail: {
+            response: 'Missing or invalid credentials provided by client',
+            cause: 'No token found',
+          },
+        })
+      );
+
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        HCCAIAssistantUnauthorizedError
+      );
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        'Missing or invalid credentials provided by client'
+      );
+    });
+
+    it('should throw HCCAIAssistantValidationError for 422 responses', async () => {
+      mockFetch.mockResolvedValue(
+        mockErrorResponse(422, 'Unprocessable Entity', {
+          detail: [{ msg: 'Query is required' }],
+        })
+      );
+
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        HCCAIAssistantValidationError
+      );
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        'Query is required'
+      );
+    });
+
+    it('should throw HCCAIAssistantQuotaExceededError for 429 responses', async () => {
+      mockFetch.mockResolvedValue(
+        mockErrorResponse(429, 'Too Many Requests', {
+          detail: {
+            response:
+              'The token quota for model gpt-4-turbo has been exceeded.',
+            cause: 'User has no available tokens',
+          },
+        })
+      );
+
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        HCCAIAssistantQuotaExceededError
+      );
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        'The token quota for model gpt-4-turbo has been exceeded.'
+      );
+    });
+
+    it('should throw HCCAIAssistantServerError for 500+ responses', async () => {
+      mockFetch.mockResolvedValue(
+        mockErrorResponse(500, 'Internal Server Error', {
+          detail: {
+            response: 'An unexpected error occurred',
+            cause: 'Backend unavailable',
+          },
+        })
+      );
+
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        HCCAIAssistantServerError
+      );
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        'An unexpected error occurred'
+      );
+    });
+
+    it('should throw HCCAIAssistantServerError for 502 responses', async () => {
+      mockFetch.mockResolvedValue(mockErrorResponse(502, 'Bad Gateway'));
+
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        HCCAIAssistantServerError
+      );
+    });
+
+    it('should throw AIClientError for unhandled 4xx responses', async () => {
+      mockFetch.mockResolvedValue(
+        mockErrorResponse(403, 'Forbidden', {
+          detail: {
+            response: 'User does not have permission to access this endpoint',
+          },
+        })
+      );
+
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        AIClientError
+      );
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        'User does not have permission to access this endpoint'
+      );
+    });
+
+    it('should extract message from FastAPI validation format', async () => {
+      mockFetch.mockResolvedValue(
+        mockErrorResponse(422, 'Unprocessable Entity', {
+          detail: [{ msg: 'field required' }],
+        })
+      );
+
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        'field required'
+      );
+    });
+
+    it('should use status text as fallback when error body has no detail', async () => {
+      mockFetch.mockResolvedValue(mockErrorResponse(404, 'Not Found'));
+
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        'HTTP 404'
+      );
+    });
+
+    it('should handle unparseable JSON in error responses', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: jest.fn().mockRejectedValue(new Error('Invalid JSON')),
+      } as unknown as Response);
+
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        HCCAIAssistantServerError
+      );
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        'Server error'
+      );
+    });
+
+    it('should wrap network errors in AIClientError', async () => {
+      mockFetch.mockRejectedValue(new Error('Failed to fetch'));
+
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        AIClientError
+      );
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        'Failed to fetch'
+      );
+    });
+
+    it('should wrap non-Error throws in AIClientError', async () => {
+      mockFetch.mockRejectedValue('something went wrong');
+
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        AIClientError
+      );
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        'An unknown error occurred'
+      );
+    });
+
+    it('should re-throw AIClientError without wrapping', async () => {
+      const original = new AIClientError(
+        429,
+        'Too Many Requests',
+        'Rate limited'
+      );
+      mockFetch.mockRejectedValue(original);
+
+      await expect(client.sendMessage('conv', 'test')).rejects.toThrow(
+        original
+      );
+    });
+
+    it('should propagate errors from healthCheck', async () => {
+      mockFetch.mockRejectedValue(new Error('Health check failed'));
+
+      await expect(client.healthCheck()).rejects.toThrow(AIClientError);
+      await expect(client.healthCheck()).rejects.toThrow('Health check failed');
+    });
+  });
+});

--- a/packages/hcc-ai-assistant-client/src/lib/client.ts
+++ b/packages/hcc-ai-assistant-client/src/lib/client.ts
@@ -1,0 +1,256 @@
+import {
+  IAIClient,
+  IConversation,
+  IConversationHistoryResponse,
+  IInitErrorResponse,
+  IMessageResponse,
+  ISendMessageOptions,
+  IRequestOptions,
+  ClientInitLimitation,
+  AIClientError,
+} from '@redhat-cloud-services/ai-client-common';
+import {
+  HCCAIAssistantAdditionalProperties,
+  HCCAIAssistantClientConfig,
+  HCCAIAssistantRequest,
+  HCCAIAssistantAPIResponse,
+  HCCAIAssistantConversationsListResponse,
+  HCCAIAssistantConversationResponse,
+  HCCAIAssistantUnauthorizedError,
+  HCCAIAssistantValidationError,
+  HCCAIAssistantQuotaExceededError,
+  HCCAIAssistantServerError,
+  extractErrorMessage,
+} from './types';
+
+const TEMP_CONVERSATION_ID = '__temp_hcc_ai_assistant_conversation__';
+
+export class HCCAIAssistantClient
+  implements IAIClient<HCCAIAssistantAdditionalProperties>
+{
+  private readonly baseUrl: string;
+  private readonly fetchFunction: typeof fetch;
+  private readonly provider?: string;
+  private readonly model?: string;
+  private readonly generateTopicSummary?: boolean;
+
+  constructor(config: HCCAIAssistantClientConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/$/, '');
+    this.fetchFunction = config.fetchFunction || fetch;
+    this.provider = config.provider;
+    this.model = config.model;
+    this.generateTopicSummary = config.generateTopicSummary;
+  }
+
+  async init(): Promise<{
+    conversations: IConversation[];
+    limitation?: ClientInitLimitation;
+    error?: IInitErrorResponse;
+  }> {
+    try {
+      const response =
+        await this.makeRequest<HCCAIAssistantConversationsListResponse>(
+          '/v1/conversations',
+          { method: 'GET' }
+        );
+
+      return {
+        conversations: response.conversations.map((conv) => ({
+          id: conv.conversation_id,
+          title: conv.topic_summary || 'New Conversation',
+          locked: false,
+          createdAt: conv.created_at ? new Date(conv.created_at) : new Date(),
+        })),
+      };
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+
+  async sendMessage<
+    T extends Record<string, unknown> = Record<string, unknown>,
+    R extends Record<string, unknown> = Record<string, unknown>
+  >(
+    conversationId: string,
+    message: string,
+    options?: ISendMessageOptions<T, R>
+  ): Promise<IMessageResponse<HCCAIAssistantAdditionalProperties>> {
+    const request: HCCAIAssistantRequest = {
+      query: message,
+    };
+
+    if (this.provider !== undefined) {
+      request.provider = this.provider;
+    }
+
+    if (this.model !== undefined) {
+      request.model = this.model;
+    }
+
+    if (this.generateTopicSummary !== undefined) {
+      request.generate_topic_summary = this.generateTopicSummary;
+    }
+
+    if (conversationId !== TEMP_CONVERSATION_ID) {
+      request.conversation_id = conversationId;
+    }
+
+    try {
+      const response = await this.makeRequest<HCCAIAssistantAPIResponse>(
+        '/v1/query',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...options?.headers,
+          },
+          body: JSON.stringify(request),
+          signal: options?.signal,
+        }
+      );
+
+      return {
+        messageId: crypto.randomUUID(),
+        answer: response.response,
+        conversationId: response.conversation_id,
+        date: new Date(),
+        additionalAttributes: {
+          referencedDocuments: response.referenced_documents,
+          truncated: response.truncated,
+          inputTokens: response.input_tokens,
+          outputTokens: response.output_tokens,
+        },
+      };
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+
+  async createNewConversation(): Promise<IConversation> {
+    return {
+      id: TEMP_CONVERSATION_ID,
+      title: 'New Conversation',
+      locked: false,
+      createdAt: new Date(),
+    };
+  }
+
+  async getConversationHistory(
+    conversationId: string,
+    options?: IRequestOptions
+  ): Promise<IConversationHistoryResponse<HCCAIAssistantAdditionalProperties>> {
+    try {
+      const response =
+        await this.makeRequest<HCCAIAssistantConversationResponse>(
+          `/v1/conversations/${conversationId}`,
+          {
+            method: 'GET',
+            headers: options?.headers,
+            signal: options?.signal,
+          }
+        );
+
+      return response.chat_history.flatMap((turn) =>
+        turn.messages
+          .filter((msg) => msg.type === 'user' || msg.type === 'assistant')
+          .map((msg) => ({
+            message_id: crypto.randomUUID(),
+            answer: msg.type === 'assistant' ? msg.content : '',
+            input: msg.type === 'user' ? msg.content : '',
+            date: new Date(turn.started_at),
+            additionalAttributes: msg.referenced_documents
+              ? { referencedDocuments: msg.referenced_documents }
+              : undefined,
+          }))
+      );
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+
+  async healthCheck(options?: IRequestOptions): Promise<unknown> {
+    try {
+      return await this.makeRequest('/v1/health', {
+        method: 'GET',
+        headers: options?.headers,
+        signal: options?.signal,
+      });
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+
+  private async makeRequest<T = unknown>(
+    endpoint: string,
+    options: RequestInit
+  ): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+
+    const response = await this.fetchFunction(url, {
+      ...options,
+      headers: {
+        Accept: 'application/json',
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => null);
+
+      if (response.status === 401) {
+        throw new HCCAIAssistantUnauthorizedError(
+          extractErrorMessage(errorBody, 'Unauthorized'),
+          errorBody
+        );
+      }
+
+      if (response.status === 422) {
+        throw new HCCAIAssistantValidationError(
+          extractErrorMessage(errorBody, 'Validation error'),
+          errorBody
+        );
+      }
+
+      if (response.status === 429) {
+        throw new HCCAIAssistantQuotaExceededError(
+          extractErrorMessage(errorBody, 'Quota exceeded'),
+          errorBody
+        );
+      }
+
+      if (response.status >= 500) {
+        throw new HCCAIAssistantServerError(
+          response.status,
+          extractErrorMessage(errorBody, 'Server error'),
+          errorBody
+        );
+      }
+
+      throw new AIClientError(
+        response.status,
+        response.statusText,
+        extractErrorMessage(errorBody, `HTTP ${response.status}`),
+        errorBody
+      );
+    }
+
+    return response.json();
+  }
+
+  private handleError(error: unknown): never {
+    if (error instanceof AIClientError) {
+      throw error;
+    }
+
+    if (error instanceof Error) {
+      throw new AIClientError(0, 'Network Error', error.message, error);
+    }
+
+    throw new AIClientError(
+      0,
+      'Unknown Error',
+      'An unknown error occurred',
+      error
+    );
+  }
+}

--- a/packages/hcc-ai-assistant-client/src/lib/index.ts
+++ b/packages/hcc-ai-assistant-client/src/lib/index.ts
@@ -1,0 +1,2 @@
+export { HCCAIAssistantClient } from './client';
+export * from './types';

--- a/packages/hcc-ai-assistant-client/src/lib/types.ts
+++ b/packages/hcc-ai-assistant-client/src/lib/types.ts
@@ -1,0 +1,143 @@
+import {
+  IBaseClientConfig,
+  IFetchFunction,
+  AIClientError,
+} from '@redhat-cloud-services/ai-client-common';
+
+export interface HCCAIAssistantClientConfig extends IBaseClientConfig {
+  baseUrl: string;
+  fetchFunction?: IFetchFunction;
+  provider?: string;
+  model?: string;
+  generateTopicSummary?: boolean;
+}
+
+export interface HCCAIAssistantRequest {
+  query: string;
+  provider?: string;
+  model?: string;
+  generate_topic_summary?: boolean;
+  conversation_id?: string;
+}
+
+export interface HCCAIAssistantAPIResponse {
+  conversation_id: string;
+  response: string;
+  rag_chunks: unknown[];
+  referenced_documents: unknown[];
+  truncated: boolean;
+  input_tokens: number;
+  output_tokens: number;
+  available_quotas: Record<string, unknown>;
+  tool_calls: unknown[];
+  tool_results: unknown[];
+}
+
+export interface HCCAIAssistantConversationDetails {
+  conversation_id: string;
+  created_at: string | null;
+  last_message_at: string | null;
+  message_count: number | null;
+  last_used_model: string | null;
+  last_used_provider: string | null;
+  topic_summary: string | null;
+}
+
+export interface HCCAIAssistantConversationsListResponse {
+  conversations: HCCAIAssistantConversationDetails[];
+}
+
+export interface HCCAIAssistantMessage {
+  content: string;
+  type: 'user' | 'assistant' | 'system' | 'developer';
+  referenced_documents?:
+    | { doc_url?: string; doc_title?: string; source?: string }[]
+    | null;
+}
+
+export interface HCCAIAssistantConversationTurn {
+  messages: HCCAIAssistantMessage[];
+  provider: string;
+  model: string;
+  started_at: string;
+  completed_at: string;
+}
+
+export interface HCCAIAssistantConversationResponse {
+  conversation_id: string;
+  chat_history: HCCAIAssistantConversationTurn[];
+}
+
+export interface HCCAIAssistantAdditionalProperties
+  extends Record<string, unknown> {
+  referencedDocuments?: unknown[];
+  truncated?: boolean;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+export class HCCAIAssistantUnauthorizedError extends AIClientError {
+  constructor(message: string, details?: unknown) {
+    super(401, 'Unauthorized', message, details);
+    this.name = 'HCCAIAssistantUnauthorizedError';
+  }
+}
+
+export class HCCAIAssistantValidationError extends AIClientError {
+  constructor(message: string, validationDetails?: unknown) {
+    super(422, 'Validation Error', message, validationDetails);
+    this.name = 'HCCAIAssistantValidationError';
+  }
+}
+
+export class HCCAIAssistantQuotaExceededError extends AIClientError {
+  constructor(message: string, details?: unknown) {
+    super(429, 'Quota Exceeded', message, details);
+    this.name = 'HCCAIAssistantQuotaExceededError';
+  }
+}
+
+export class HCCAIAssistantServerError extends AIClientError {
+  constructor(status: number, message: string, serverDetails?: unknown) {
+    super(status, 'Server Error', message, serverDetails);
+    this.name = 'HCCAIAssistantServerError';
+  }
+}
+
+export function extractErrorMessage(
+  errorBody: unknown,
+  fallback: string
+): string {
+  if (typeof errorBody !== 'object' || errorBody === null) {
+    return fallback;
+  }
+
+  const body = errorBody as Record<string, unknown>;
+  const detail = body['detail'];
+
+  // Lightspeed Stack format: { detail: { response: "...", cause: "..." } }
+  if (typeof detail === 'object' && detail !== null && !Array.isArray(detail)) {
+    const detailObj = detail as Record<string, unknown>;
+    if (typeof detailObj['response'] === 'string') {
+      return detailObj['response'];
+    }
+  }
+
+  // FastAPI validation format: { detail: [{ msg: "..." }] }
+  if (Array.isArray(detail) && detail.length > 0) {
+    const msg = (detail[0] as Record<string, unknown>)?.['msg'];
+    if (typeof msg === 'string') {
+      return msg;
+    }
+  }
+
+  if (typeof body['message'] === 'string') {
+    return body['message'];
+  }
+
+  if (typeof body['error'] === 'string') {
+    return body['error'];
+  }
+
+  return fallback;
+}

--- a/packages/hcc-ai-assistant-client/tsconfig.json
+++ b/packages/hcc-ai-assistant-client/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": false,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/hcc-ai-assistant-client/tsconfig.lib.json
+++ b/packages/hcc-ai-assistant-client/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "module": "commonjs",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/hcc-ai-assistant-client/tsconfig.spec.json
+++ b/packages/hcc-ai-assistant-client/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,6 +35,9 @@
       "@redhat-cloud-services/aai-client": ["packages/aai-client/src/index.ts"],
       "@redhat-cloud-services/rhel-lightspeed-client": [
         "packages/rhel-lightspeed-client/src/index.ts"
+      ],
+      "@redhat-cloud-services/hcc-ai-assistant-client": [
+        "packages/hcc-ai-assistant-client/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
## Summary
  
  - Adds `@redhat-cloud-services/hcc-ai-assistant-client` package implementing `IAIClient` against the lightspeed-stack `/v1/query`, `/v1/conversations`, and `/v1/health` endpoints
  - Types and error handling are modeled after the lightspeed-stack API contract, including both the `{ detail: { response, cause } }` error format and FastAPI's `{ detail: [{ msg }] }` validation format
  - Not all API parameters or endpoints are exposed yet — only the ones needed for the current frontend integration (query, conversation list, conversation history, health check)

  ## What's included

  - `client.ts` — `HCCAIAssistantClient` with `init()`, `sendMessage()`, `createNewConversation()`, `getConversationHistory()`, `healthCheck()`
  - `types.ts` — Request/response interfaces matching lightspeed-stack, typed error classes for `401`, `422`, `429`, and `5xx`, `extractErrorMessage` helper
  - `client.spec.ts` — 39 unit tests covering all methods, error paths, and `extractErrorMessage` branches

  ## Test plan

  - [x] `nx test hcc-ai-assistant-client` — 39 tests pass
  - [x] `nx build hcc-ai-assistant-client` — builds successfully