### PR TITLE
feat: add .npmignore files to all packages to control published content

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+# Source maps (not needed by consumers)
+*.js.map
+# Test files (should not be in dist, but defensive)
+*.test.*
+*.spec.*
+__snapshots__/
+__mocks__/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,9 @@
 # All Konflux tekton configuration changes review from admins
 #.tekton/** @RedHatInsights/experience-services-admins
 
+# Protect package publish contents control
+.npmignore @RedHatInsights/experience-services-admins
+
 # CODEOWNERS file itself requires admin review to prevent bypass attacks
 # Must come after wildcard so this rule takes precedence (last match wins)
 CODEOWNERS @RedHatInsights/experience-services-admins

--- a/packages/aai-client/project.json
+++ b/packages/aai-client/project.json
@@ -18,7 +18,7 @@
         "outputPath": "dist/packages/aai-client",
         "main": "packages/aai-client/src/index.ts",
         "tsConfig": "packages/aai-client/tsconfig.lib.json",
-        "assets": []
+        "assets": [".npmignore"]
       }
     },
     "nx-release-publish": {

--- a/packages/ai-client-common/project.json
+++ b/packages/ai-client-common/project.json
@@ -18,7 +18,7 @@
         "outputPath": "dist/packages/ai-client-common",
         "main": "packages/ai-client-common/src/index.ts",
         "tsConfig": "packages/ai-client-common/tsconfig.lib.json",
-        "assets": ["packages/ai-client-common/*.md"]
+        "assets": ["packages/ai-client-common/*.md", ".npmignore"]
       }
     },
     "test": {

--- a/packages/ai-client-state/project.json
+++ b/packages/ai-client-state/project.json
@@ -18,7 +18,7 @@
         "outputPath": "dist/packages/ai-client-state",
         "main": "packages/ai-client-state/src/index.ts",
         "tsConfig": "packages/ai-client-state/tsconfig.lib.json",
-        "assets": ["packages/ai-client-state/*.md"]
+        "assets": ["packages/ai-client-state/*.md", ".npmignore"]
       }
     },
     "test": {

--- a/packages/ai-react-state/project.json
+++ b/packages/ai-react-state/project.json
@@ -18,7 +18,7 @@
         "outputPath": "dist/packages/ai-react-state",
         "main": "packages/ai-react-state/src/index.ts",
         "tsConfig": "packages/ai-react-state/tsconfig.lib.json",
-        "assets": []
+        "assets": [".npmignore"]
       }
     },
     "test": {

--- a/packages/ansible-lightspeed/project.json
+++ b/packages/ansible-lightspeed/project.json
@@ -18,7 +18,7 @@
         "outputPath": "dist/packages/ansible-lightspeed",
         "main": "packages/ansible-lightspeed/src/index.ts",
         "tsConfig": "packages/ansible-lightspeed/tsconfig.lib.json",
-        "assets": []
+        "assets": [".npmignore"]
       }
     },
     "nx-release-publish": {

--- a/packages/arh-client/project.json
+++ b/packages/arh-client/project.json
@@ -18,7 +18,7 @@
         "outputPath": "dist/packages/arh-client",
         "main": "packages/arh-client/src/index.ts",
         "tsConfig": "packages/arh-client/tsconfig.lib.json",
-        "assets": []
+        "assets": [".npmignore"]
       }
     },
     "nx-release-publish": {

--- a/packages/lightspeed-client/project.json
+++ b/packages/lightspeed-client/project.json
@@ -18,7 +18,7 @@
         "outputPath": "dist/packages/lightspeed-client",
         "main": "packages/lightspeed-client/src/index.ts",
         "tsConfig": "packages/lightspeed-client/tsconfig.lib.json",
-        "assets": []
+        "assets": [".npmignore"]
       }
     },
     "nx-release-publish": {

--- a/packages/rhel-lightspeed-client/project.json
+++ b/packages/rhel-lightspeed-client/project.json
@@ -18,7 +18,7 @@
         "outputPath": "dist/packages/rhel-lightspeed-client",
         "main": "packages/rhel-lightspeed-client/src/index.ts",
         "tsConfig": "packages/rhel-lightspeed-client/tsconfig.lib.json",
-        "assets": []
+        "assets": [".npmignore"]
       }
     },
     "nx-release-publish": {


### PR DESCRIPTION
## Summary

Adds `.npmignore` files to all 8 packages to ensure only production code is included in published npm packages.

**Jira:** [RHCLOUD-48281](https://redhat.atlassian.net/browse/RHCLOUD-48281)

## Changes

- **`.npmignore` files** created in each package under `packages/` excluding:
  - Test files (`*.spec.*`, `*.test.*`, `__tests__/`)
  - Build & dev configuration (`jest.config.*`, `tsconfig.*`, `.eslintrc.json`, `project.json`, etc.)
  - Source TypeScript files (`*.ts`, `*.tsx`) while keeping type declarations (`*.d.ts`)
- **`project.json`** updated for all 8 packages to include `.npmignore` as a build asset, so it gets copied to `dist/` during compilation
- **`CODEOWNERS`** updated with `**/.npmignore @RedHatInsights/console-framework-leads` to protect package content control

## Why build assets?

Packages in this repo are published from `dist/packages/{name}/` (not from source). The `.npmignore` files are added to the `assets` array in each package's build target so they are automatically copied to the dist directory during `nx build`.

## Verification

- `npx nx run-many --target=build` passes for all packages
- `npm pack --dry-run` in dist directories confirms only production files (`.js`, `.d.ts`, `.js.map`, `package.json`, `README.md`, `CHANGELOG.md`) are included


[RHCLOUD-48281]: https://redhat.atlassian.net/browse/RHCLOUD-48281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ